### PR TITLE
Fix for unresolved reference in surface plot

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -108,7 +108,6 @@ local function argumentsSurface(t)
     local x = nil
     local y = nil
     local z = nil
-    local format = nil
 
     if #t == 0 then
         error('empty argument list')
@@ -156,7 +155,7 @@ local function argumentsSurface(t)
     y = y:contiguous()
     z = z:contiguous()
 
-    return {x = x, y = y, z = z, format = format, legend = legend}
+    return {x = x, y = y, z = z, legend = legend}
 end
 
 function plplot.colors(axisColor, colors)

--- a/init.lua
+++ b/init.lua
@@ -108,6 +108,7 @@ local function argumentsSurface(t)
     local x = nil
     local y = nil
     local z = nil
+    local format = nil
 
     if #t == 0 then
         error('empty argument list')


### PR DESCRIPTION
The returned table from argumentsSurface was trying to reference format, which didn't exist so was throwing an exception when plotting a surface.
